### PR TITLE
Fix: process.getgid and process.getuid are not available on Windows

### DIFF
--- a/lib/report/exception-report.js
+++ b/lib/report/exception-report.js
@@ -96,8 +96,9 @@ function collectProcessEnvironmentInfo() {
 			memo[key] = process.env[key];
 			return memo;
 		}, {}),
-		gid: process.getgid(),
-		uid: process.getuid()
+		pid: process.pid,
+		gid: process.getgid ? process.getgid() : 0,
+		uid: process.getuid ? process.getuid() : 0
 	};
 }
 


### PR DESCRIPTION
Make the `gid` and `uid` properties optional and introduce a new `pid` property that is available on all platforms.

Although none of those is actually used in the report, they still threw up when running nodejs on a Windows machine.
